### PR TITLE
feat: use `updated_at` file property (stat's `modify` time) for Chronicle view

### DIFF
--- a/src/components/view/chronicle.tsx
+++ b/src/components/view/chronicle.tsx
@@ -32,22 +32,22 @@ export default function Chronicle() {
     if (!note) {
       const newNote: Note = {
         ...defaultNote,
-        id: noteId, 
-        title: date, 
+        id: noteId,
+        title: date,
         file_path: noteId,
-        is_daily: true, 
+        is_daily: true,
       };
       store.getState().upsertNote(newNote);
       const dailyDir = await joinPaths(initDir, ['daily']);
       const newDailyDir: Note = {
         ...defaultNote,
-        id: dailyDir, 
-        title: 'daily', 
+        id: dailyDir,
+        title: 'daily',
         file_path: dailyDir,
-        is_dir: true, 
+        is_dir: true,
       };
-      store.getState().upsertTree(initDir, [newDailyDir]); 
-      store.getState().upsertTree(dailyDir, [newNote]); 
+      store.getState().upsertTree(initDir, [newDailyDir]);
+      store.getState().upsertTree(dailyDir, [newNote]);
       const cNote: Notes = {};
       cNote[noteId] = newNote;
       store.getState().setCurrentNote(cNote);
@@ -96,10 +96,10 @@ function HeatMapAndList(props: Props) {
     const noteList: Note[] = Object.values(notes) || [];
     return noteList;
   }, [notes]);
-  
+
   const sortedNotes = useMemo(() => {
     const myNotes = noteList.filter(n => !n.is_daily && !n.is_dir && checkFileIsMd(n.id));
-    myNotes.sort((n1, n2) => dateCompare(n2.created_at, n1.created_at));
+    myNotes.sort((n1, n2) => dateCompare(n2.updated_at, n1.updated_at));
     return myNotes;
   }, [noteList])
 
@@ -109,7 +109,7 @@ function HeatMapAndList(props: Props) {
   }, []);
 
   const dateArr = useMemo(() => {
-    const upDates = sortedNotes.map(n => getStrDate(n.created_at));
+    const upDates = sortedNotes.map(n => getStrDate(n.updated_at));
     const dateSet = new Set(upDates);
     const dates = Array.from(dateSet);
     const first = firstDay ? [firstDay] : [];
@@ -119,10 +119,10 @@ function HeatMapAndList(props: Props) {
 
   // get notes on a date
   const getDayNotes = useCallback(
-    (date: string) => sortedNotes.filter(n => getStrDate(n.created_at) === date), 
+    (date: string) => sortedNotes.filter(n => getStrDate(n.updated_at) === date),
     [sortedNotes]
   );
-  
+
   return (
     <>
       <div className="flex items-center justify-center overlfow-auto">
@@ -135,7 +135,7 @@ function HeatMapAndList(props: Props) {
             anchor={d}
             notes={getDayNotes(d)}
             isDate={true}
-            onClick={onNewDailyNote} 
+            onClick={onNewDailyNote}
           />
         ))}
       </div>


### PR DESCRIPTION
Hi, I'm currently migrating from another note taking tool ([Zim](https://zim-wiki.org/)) which does not use the same formatting language, so I needed to mass modify my files to convert them to Markdown format using `sed` (can share the commands if anyone is interested).

While doing so, I've noticed that all my files would appear in the Chronicle view from today's date. Obviously, that's because my `sed` commands modified all the files. I went on and restored the modify time from a backup of the original files using `find . -name "*.txt" -exec bash -c 'touch -t $(date -d @$(stat --format '%Y' "../Notes.bak/{}") +%Y%m%d%H%M.%S) "{}"' \; -ls`, but the Chronicle view would still show all notes as made today. Looking at the source, I then figured that view is using the files creation time (stat's `birth` time), and my `sed` commands using inline mode created new files.
But the notion of file creation date on Linux is file system dependent, and there's no easy way to alter it.

With the change in this PRs, the Chronicle view uses the `updated_at` file property (stat's `modify` time), and notes appear when they were last modified.

If the original behavior is intended by some people, maybe it would make sense to make it an option.

PS: sorry about the trailing spaces removal changes that pollute the diff, I can revert those if desired.